### PR TITLE
Update OpenAPI schema and examples to reflect spec

### DIFF
--- a/SCIM_endpointApp_schema_representation.json
+++ b/SCIM_endpointApp_schema_representation.json
@@ -72,13 +72,13 @@
       ]
     },
     {
-      "name": "client-token",
+      "name": "clientToken",
       "type": "string",
       "description": "This attribute contains a token that the client will use to authenticate itself.  Each token may be a string up to 500 characters in length.",
       "multivalues": false,
       "required": false,
       "caseExact": true,
-      "mutability": "readWrite",
+      "mutability": "readOnly",
       "returned": "default",
       "uniqueness": "none"
     }

--- a/draft-shahzad-scim-device-model.mkd
+++ b/draft-shahzad-scim-device-model.mkd
@@ -324,7 +324,7 @@ human readable name for the application. This attribute is required and
 mutable. The attribute should be returned by default and there is no 
 uniqueness contraint on the attribute.
 
-client-token
+clientToken
 
 This attribute type string contains a token that the client will use 
 to authenticate itself.  Each token may be a string up to 500 
@@ -370,9 +370,9 @@ read only, multivalued and case sensitive.
 +-------------------+-------+-----+------+---------+--------+--------+
 | applicationName   |   F   |  T  |  F   |   RW    |  Def   |  None  |
 +-------------------+-------+-----+------+---------+--------+--------+
-| client-token      |   F   |  T  |  T   |   RW    |  Def   |  None  |
+| clientToken       |   F   |  T  |  T   |   R     |  Def   |  None  |
 +-------------------+-------+-----+------+---------+--------+--------+
-| certificateInfo   |   F   |  F  |  F   |   R     |  Def   |  None  |
+| certificateInfo   |   F   |  F  |  F   |   RW    |  Def   |  None  |
 +-------------------+-------+-----+------+---------+--------+--------+
 | rootCN            |   F   |  T  |  T   |   R     |  Def   |  None  |
 +-------------------+-------+-----+------+---------+--------+--------+
@@ -386,13 +386,13 @@ read only, multivalued and case sensitive.
 T = True, F = False, R = ReadOnly, RW = ReadWrite, Manuf = Manufactirer
 and Def = Default)"}
 
-Note that attributes client-token and certificateInfo are used for the
+Note that attributes clientToken and certificateInfo are used for the
 authentication of the application. Both SHALL NOT exist together in the
-SCIM object. Either client-token or certificateInfo SHALL be present
+SCIM object. Either clientToken or certificateInfo SHALL be present
 in the SCIM object.
 
 An example of a endpointApp SCIM object is as follows. Note that since
-certificateInfo is present in the example, client-token attribute is 
+certificateInfo is present in the example, clientToken attribute is 
 NULL. 
 
 ~~~~~~~~~
@@ -480,7 +480,7 @@ scalability of pairing methods in the future, they are represented as
 extensions to incorporate various attributes that are part of the
 respective pairing process. Pairing method extensions are nested
 inside the BLE extension. It is required, case sensitive, mutable, and 
-returned by deafult.
+returned by default.
 
 ### BLE Pairing Method Extensions
 
@@ -748,7 +748,7 @@ urn:ietf:params:scim:schemas:extension:endpointAppsExt:2.0:Device
 ### Singular Attributes
 
 
-DeviceControlEnterpriseEndpoint
+deviceControlEnterpriseEndpoint
 
 Device control apps use this URL of the enterprise endpoint to reach
 the enterprise gateway. When the enterprise receives the SCIM object from
@@ -792,9 +792,9 @@ and returned by default.
 | Attribute          | Multi | Req | Case | Mutable | Return | Unique |
 |                    | Value |     | Exact|         |        |        |
 +====================+=======+=====+======+=========+========+========+
-| DevContEntEndpoint |   F   |  T  |  T   |   RW    |  Def   | Ent    |
+| devContEntEndpoint |   F   |  T  |  T   |   R     |  Def   | Ent    |
 +--------------------+-------+-----+------+---------+--------+--------+
-| telEntEndpoint     |   F   |  T  |  T   |   RW    |  Def   | Ent    |
+| telEntEndpoint     |   F   |  T  |  T   |   R     |  Def   | Ent    |
 +--------------------+-------+-----+------+---------+--------+--------+
 | applications       |   T   |  T  |  F   |   RW    |  Def   | None   |
 +--------------------+-------+-----+------+---------+--------+--------+
@@ -805,7 +805,7 @@ and returned by default.
 ~~~
 {: #tabEndpointAppsExt title="Characteristics of EndpointAppsExt extension schema 
 attributes. DevContEntEndpoint represents attribute 
-DeviceControlEnterpriseEndpoint and telEntEndpoint represents 
+deviceControlEnterpriseEndpoint and telEntEndpoint represents 
 telemetryEnterpriseEndpoint. (Req = Required, T = True, F = False, 
 R = ReadOnly, RW = ReadWrite, Ent = Enterprise, and Def = Default)."}
 

--- a/examples/SCIM_device_endpoints_with_ble_object.json
+++ b/examples/SCIM_device_endpoints_with_ble_object.json
@@ -4,13 +4,14 @@
      "urn:ietf:params:scim:schemas:extension:endpointAppsExt:2.0:Device"],
 
   "id": "e9e30dba-f08f-4109-8486-d5c6a3316111",
-  "displayName": "BLE Heart Monitor",
+  "deviceDisplayName": "BLE Heart Monitor",
   "adminState": true,
-    "urn:ietf:params:scim:schemas:extension:ble:2.0:Device" :
-    {          "versionSupport": ["5.3"],
+  "urn:ietf:params:scim:schemas:extension:ble:2.0:Device" : {
+    "versionSupport": ["5.3"],
     "deviceMacAddress": "2C:54:91:88:C9:E2",
-    "addressType": false,
-      "pairingMethods": [
+    "isRandom": false,
+    "separateBroadcastAddress": ["AA:BB:88:77:22:11", "AA:BB:88:77:22:12"], 
+    "pairingMethods": [
         "urn:ietf:params:scim:schemas:extension:pairingNull:2.0:Device",
         "urn:ietf:params:scim:schemas:extension:pairingJustWorks:2.0:Device",
         "urn:ietf:params:scim:schemas:extension:pairingPassKey:2.0:Device",

--- a/examples/SCIM_device_endpoints_with_ble_object.json
+++ b/examples/SCIM_device_endpoints_with_ble_object.json
@@ -40,7 +40,7 @@
         "$ref" : "https://example.com/v2/EndpointApp/e9e30dba-f08f-4109-8486-d5c6a3316333"
       }
     ],
-    "DeviceControlEnterpriseEndpoint": "https//enterprise.com/device_control_app_endpoint/",
+    "deviceControlEnterpriseEndpoint": "https//enterprise.com/device_control_app_endpoint/",
     "telemetryEnterpriseEndpoint": "https//enterprise.com/telemetry_app_endpoint/"
      
   },

--- a/examples/SCIM_endpointapp_schema_object.json
+++ b/examples/SCIM_endpointapp_schema_object.json
@@ -8,7 +8,7 @@
       "subjectName": "wwww.example.com",
       "subjectAlternativeName": ["xyz.example.com", "abc.example.com"]
   },
-  "client-token": null,
+  "clientToken": null,
   "meta": {
     "resourceType": "EndpointApp",
     "created": "2022-01-23T04:56:22Z",

--- a/extensions/SCIM_endpoint_extension_schema.json
+++ b/extensions/SCIM_endpoint_extension_schema.json
@@ -7,7 +7,7 @@
       "name": "applications",
       "type": "complex",
       "description": "Includes references to two types of application that connect with entrprise, i.e., deviceControl and telemetry.",
-      "multivalues": false,
+      "multivalues": true,
       "required": true,
       "caseExact": false,
       "mutability": "readWrite",
@@ -40,13 +40,13 @@
       ]
     },
     {
-      "name": "DeviceControlEnterpriseEndpoint",
+      "name": "deviceControlEnterpriseEndpoint",
       "type": "reference",
       "description": "The URL of the enterprise endpoint which device control apps use to reach enterprise network gateway.",
       "multivalues": false,
       "required": true,
       "caseExact": true,
-      "mutability": "readWrite",
+      "mutability": "readOnly",
       "returned": "default",
       "uniqueness": "Enterprise"
     },
@@ -57,7 +57,7 @@
       "multivalues": false,
       "required": true,
       "caseExact": true,
-      "mutability": "readWrite",
+      "mutability": "readOnly",
       "returned": "default",
       "uniqueness": "Enterprise"
     }

--- a/openapi/SCIM_endpoint_extension_schema.yml
+++ b/openapi/SCIM_endpoint_extension_schema.yml
@@ -6,14 +6,14 @@ components:
         applications:
           $ref: '#/components/schemas/applications'
         
-        DeviceControlEnterpriseEndpoint:
+        deviceControlEnterpriseEndpoint:
           type: string
           format: url
           description: The URL of the enterprise endpoint which device
                        control apps use to reach enterprise network 
                        gateway.
           nullable: false
-          readOnly: false
+          readOnly: true
           writeOnly: false
         
         telemetryEnterpriseEndpoint:
@@ -23,12 +23,12 @@ components:
                        telemetry apps use to reach enterprise network 
                        gateway.
           nullable: false
-          readOnly: false
+          readOnly: true
           writeOnly: false
 
       required:
         - applications
-        - DeviceControlEnterpriseEndpoint
+        - deviceControlEnterpriseEndpoint
         - telemetryEnterpriseEndpoint
         
     applications:

--- a/openapi/endpointapp_schema.yml
+++ b/openapi/endpointapp_schema.yml
@@ -10,7 +10,7 @@ components:
           description: "This attribute will only contain two values;
                        'deviceControl' or 'telemetry'."
           nullable: false
-          readOnly: true
+          readOnly: false
           writeOnly: false
 
         applicationName:
@@ -26,19 +26,19 @@ components:
 
       additionalProperties: true
       oneOf:
-        - $ref: '#/components/schemas/client-token'
+        - $ref: '#/components/schemas/clientToken'
         - $ref: '#/components/schemas/certificateInfo'
 
       allOf:
         - $ref: '#/components/schemas/CommonAttributes'
 
-    client-token:
+    clientToken:
       type: string
       description: "This attribute contains a token that the client
                     will use to authenticate itself. Each token may
                     be a string up to 500 characters in length."
       nullable: true
-      readOnly: false
+      readOnly: true
       writeOnly: false
 
     certificateInfo:
@@ -89,7 +89,7 @@ components:
           items:
             type: string
             enum:
-              - urn:ietf:params:scim:schemas:core:2.0:Device
+              - urn:ietf:params:scim:schemas:core:2.0:EndpointApp
           description: The list of schemas that define the resource.
           nullable: false
         id:
@@ -98,13 +98,6 @@ components:
           description: The unique identifier for a resource.
           nullable: false
           readOnly: true
-          writeOnly: false
-        externalId:
-          type: string
-          description: An identifier for the resource that is defined
-                       by the provisioning client.
-          nullable: true
-          readOnly: false
           writeOnly: false
         meta:
           type: object

--- a/openapi/scim_device_api.yml
+++ b/openapi/scim_device_api.yml
@@ -21,9 +21,9 @@ components:
                   items:
                     type: string
                     enum:
-                      - urn:ietf:params:scim:schemas:extension:endpointApps:2.0:Device
-                urn:ietf:params:scim:schemas:extension:endpointApps:2.0:Device:
-                  $ref: './SCIM_endpoint_extension_schema.yml#/components/schemas/EndpointAppsExtension'
+                      - urn:ietf:params:scim:schemas:extension:endpointAppsExt:2.0:Device
+                urn:ietf:params:scim:schemas:extension:endpointAppsExt:2.0:Device:
+                  $ref: './SCIM_endpoint_extension_schema.yml#/components/schemas/EndpointAppsExt'
                   required: true
 
 paths:
@@ -101,3 +101,39 @@ paths:
       responses:
         "204":
           description: No Content
+  /EndpointApps:
+    post:
+      summary: Create a new endpoint app
+      operationId: createEndpointApp
+      requestBody:
+        required: true
+        content:
+          application/scim+json:
+            schema:
+              $ref: "./endpointapp_schema.yml#/components/schemas/EndpointApp"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/scim+json:
+              schema:
+                $ref: "./endpointapp_schema.yml#/components/schemas/EndpointApp"
+  /EndpointApps/{id}:
+    get:
+      summary: Get an endpoint app by ID
+      description: Returns a single endpoint app by its ID.
+      operationId: getEndpointAppById
+      parameters:
+        - name: id
+          in: path
+          description: The ID of the endpoint app to return.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/scim+json:
+              schema:
+                $ref: "./endpointapp_schema.yml#/components/schemas/EndpointApp"


### PR DESCRIPTION
This PR includes changes from #12 along with fixes to the examples to reflect the spec correctly. 
This also includes the following changes to the draft and OpenAPI schema to make them consistent: 
1. Changed `client-token` to `clientToken` to be more consistent with the other fields in the schema
2. Changed the `clientToken`, `deviceControlEnterpriseEndpoint` and `telemetryEnterpriseEndpoint` mutability to readOnly from readWrite. 
3. Made the `applications` attribute in the endpoint apps schema multivalued in the json schema to reflect the draft. 
4. Updated the examples to reflect the correct schema. 