### PR TITLE
Mobility flag added in BLE extension

### DIFF
--- a/draft-ietf-scim-device-model.mkd
+++ b/draft-ietf-scim-device-model.mkd
@@ -461,6 +461,13 @@ A string value, Identity resolving key, which is unique for every
 device. It is used to resolve the random address. It is required when 
 addressType is TRUE. It is mutable and return by default.
 
+mobility
+
+A boolean attribute to enable mobility on BLE device. If set to True, 
+the BLE device will automatically connect to the closest AP. For 
+example, BLE device is connected with AP-1 and moves out of range but 
+comes in range of AP-2, it will be disconnected with AP-1 and connects 
+with AP-2. It is returned by default and mutable.
 
 ### Multivalued Attributes
 
@@ -555,6 +562,8 @@ default if it exists.
 | irk                |   F   |  F  |  F   |   RW    |  Def   | Manuf  |
 +--------------------+-------+-----+------+---------+--------+--------+
 | versionSupport     |   T   |  T  |  F   |   RW    |  Def   | None   |
++--------------------+-------+-----+------+---------+--------+--------+
+| mobility           |   F   |  F  |  F   |   RW    |  Def   | None   |
 +--------------------+-------+-----+------+---------+--------+--------+
 | pairingMethods     |   T   |  T  |  T   |   RW    |  Def   | None   |
 +--------------------+-------+-----+------+---------+--------+--------+

--- a/examples/SCIM_device_ble_object.json
+++ b/examples/SCIM_device_ble_object.json
@@ -10,6 +10,7 @@
     "deviceMacAddress": "2C:54:91:88:C9:E2",
     "isRandom": false,
     "separateBroadcastAddress": ["AA:BB:88:77:22:11", "AA:BB:88:77:22:12"], 
+    "mobility": true,
     "pairingMethods": ["urn:ietf:params:scim:schemas:extension:pairingNull:2.0:Device",
         "urn:ietf:params:scim:schemas:extension:pairingJustWorks:2.0:Device",
         "urn:ietf:params:scim:schemas:extension:pairingPassKey:2.0:Device",

--- a/examples/SCIM_device_endpoints_with_ble_object.json
+++ b/examples/SCIM_device_endpoints_with_ble_object.json
@@ -2,7 +2,6 @@
   "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Device",
      "urn:ietf:params:scim:schemas:extension:ble:2.0:Device",
      "urn:ietf:params:scim:schemas:extension:endpointAppsExt:2.0:Device"],
-
   "id": "e9e30dba-f08f-4109-8486-d5c6a3316111",
   "deviceDisplayName": "BLE Heart Monitor",
   "adminState": true,
@@ -10,7 +9,8 @@
     "versionSupport": ["5.3"],
     "deviceMacAddress": "2C:54:91:88:C9:E2",
     "isRandom": false,
-    "separateBroadcastAddress": ["AA:BB:88:77:22:11", "AA:BB:88:77:22:12"], 
+    "separateBroadcastAddress": ["AA:BB:88:77:22:11", "AA:BB:88:77:22:12"],
+    "mobility": false,
     "pairingMethods": [
         "urn:ietf:params:scim:schemas:extension:pairingNull:2.0:Device",
         "urn:ietf:params:scim:schemas:extension:pairingJustWorks:2.0:Device",
@@ -43,7 +43,6 @@
     ],
     "deviceControlEnterpriseEndpoint": "https//enterprise.com/device_control_app_endpoint/",
     "telemetryEnterpriseEndpoint": "https//enterprise.com/telemetry_app_endpoint/"
-     
   },
 
   

--- a/extensions/SCIM_BLE_extension_schema.json
+++ b/extensions/SCIM_BLE_extension_schema.json
@@ -60,6 +60,17 @@
         "uniqueness": "Manufacturer"
       },
       {
+        "name": "mobility",
+        "type": "bool",
+        "description": "If set to True, the BLE device will automatically connect to the closest AP. For example, BLE device is connected with AP-1 and moves out of range but comes in range of AP-2, it will be disconnected with AP-1 and connects with AP-2.",
+        "multivalues": false,
+        "required": false,
+        "caseExact": false,
+        "mutability": "readWrite",
+        "returned": "default",
+        "uniqueness": "none"
+      },
+      {
         "name": "pairingMethods",
         "type": "string",
         "description": "List of pairing methods associated with the ble device, stored as schema URI.",

--- a/openapi/SCIM_BLE_extension_schema.yml
+++ b/openapi/SCIM_BLE_extension_schema.yml
@@ -66,6 +66,17 @@ components:
           nullable: true
           readOnly: false
           writeOnly: false
+        mobility:
+          type: boolean
+          description: If set to True, the BLE device will 
+                       automatically connect to the closest AP. For 
+                       example, BLE device is connected with AP-1 and 
+                       moves out of range but comes in range of AP-2, 
+                       it will be disconnected with AP-1 and connects 
+                       with AP-2.
+          nullable: false
+          readOnly: false
+          writeOnly: false
         pairingMethods:
           type: array
           items:


### PR DESCRIPTION
This PR proposes to add a mobility flag to the BLE extension schema. 
This `mobility` attribute is used to let the network know if it should expect the BLE device to move out of range and be able to connect to multiple access points. 